### PR TITLE
Don't build restbed tests as they aren't needed for the docker image

### DIFF
--- a/build/base/Dockerfile
+++ b/build/base/Dockerfile
@@ -7,7 +7,7 @@ WORKDIR /src
 RUN git clone --recursive https://github.com/corvusoft/restbed.git
 RUN mkdir restbed/build
 WORKDIR restbed/build
-RUN cmake -DBUILD_SSL=NO ..
+RUN cmake -DBUILD_SSL=NO -DBUILD_TESTS=NO ..
 RUN make install
 RUN cp -r ../distribution/include/* /usr/local/include
 RUN cp -r ../distribution/library/* /usr/lib

--- a/build/base/Dockerfile
+++ b/build/base/Dockerfile
@@ -10,7 +10,7 @@ WORKDIR restbed/build
 RUN cmake -DBUILD_SSL=NO -DBUILD_TESTS=NO ..
 RUN make install
 RUN cp -r ../distribution/include/* /usr/local/include
-RUN cp -r ../distribution/library/* /usr/lib
+RUN cp -r ../distribution/lib/* /usr/lib
 
 WORKDIR /
 RUN git clone https://github.com/vertcoin/vertcoin

--- a/vertcoin-mainnet.yml
+++ b/vertcoin-mainnet.yml
@@ -14,7 +14,7 @@ services:
     command: -rpcuser=middleware -rpcpassword=middleware -rpcallowip=0.0.0.0/0 -rpcport=8332 -txindex
 
   vtc-middleware-cpp-main:
-    image: vtc-wallet-middleware
+    image: blkidx
     restart: always
     environment:
       - COIND_HOST=vertcoind-main


### PR DESCRIPTION
Building the restbed tests is otherwise the majority of the docker image build time. 

Also update the build Dockerfile to reflect restbed's new directory structure. 